### PR TITLE
Trimmed newlines from end of course descriptions

### DIFF
--- a/server/import-courses.js
+++ b/server/import-courses.js
@@ -88,7 +88,7 @@ async function fetchSections(term) {
 
 function extractDescription(section) {
   let desc = section.courseDescription;
-  return desc ? desc.substring(desc.lastIndexOf('\n') + 1) : '';
+  return desc ? desc.substring(desc.trim().lastIndexOf('\n') + 1) : '';
 }
 
 function extractTitle(section) {


### PR DESCRIPTION
This fix allows course section descriptions that end in newlines to be imported.

Examples from 201910:
CSE 252
HST 246
MTH 104

There is still the occasional newline in the middle of course descriptions that this doesn't catch, but that has an impact on the description display so I do not resolve it here.  Logged to #6.