### PR TITLE
update api calls to new miami api

### DIFF
--- a/server/import-courses.js
+++ b/server/import-courses.js
@@ -31,8 +31,8 @@ async function fetchTerms(db) {
     name: term.name.replace(/ (Semester|Term) /, ' ')
   });
 
-  const res = await axios.get('https://ws.muohio.edu/academicTerms');
-  return res.data.academicTerm
+  const res = await axios.get('https://ws.miamioh.edu/api/academic/banner/v2/academicTerms');
+  return res.data.data
     .filter(term => term.displayTerm == 'true')
     .sort((a, b) => b.termId - a.termId)
     .slice(0, 3)


### PR DESCRIPTION
This *should* fix the error that is currently popping up that stops Miami scheduler from building. I had to change the way that available terms are picked due to the fact that there is no longer an academicTerms endpoint.